### PR TITLE
chore: gitlab pipelines cleanup

### DIFF
--- a/bricks/gitlab_pipelines/CHANGELOG.md
+++ b/bricks/gitlab_pipelines/CHANGELOG.md
@@ -7,6 +7,7 @@
 - add missing `=` in export method flag when building ipa
 - wrap `groups` flag value with quotation marks
 - replace `pod deintegrate` in deploy workflow with deleting `Pods` and `.gradle` directories instead
+- add build_runner steps respectively
 
 # 0.2.0
 - Add pipeline for Code Review

--- a/bricks/gitlab_pipelines/CHANGELOG.md
+++ b/bricks/gitlab_pipelines/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.3.0
+- remove unused `setup` stage
+- remove unnecessary setting `.pre` and `.post` in stages
+- remove unnecessary `pod deintegrate` in `test` workflow
+- remove redundant `flutter pub get` when building apk and ipa
+- remove checking to include export method flag when building ipa to always using ad hoc
+- add missing `=` in export method flag when building ipa
+- wrap `groups` flag value with quotation marks
+- replace `pod deintegrate` in deploy workflow with deleting `Pods` and `.gradle` directories instead
+
 # 0.2.0
 - Add pipeline for Code Review
 - Rename existing Review pipeline to Test and always trigger on push

--- a/bricks/gitlab_pipelines/__brick__/.gitlab-ci.yml
+++ b/bricks/gitlab_pipelines/__brick__/.gitlab-ci.yml
@@ -1,13 +1,10 @@
 stages:
-  - .pre
   - Check Format
   - Testing
-  - Setup
   - Build
   - Distribution
   - External
   - Reviewer
-  - .post
 
 include:
   - local: '.gitlab/test.yml'

--- a/bricks/gitlab_pipelines/__brick__/.gitlab/deploy.yml
+++ b/bricks/gitlab_pipelines/__brick__/.gitlab/deploy.yml
@@ -14,7 +14,6 @@ variables:
   IOS_FIREBASE_APP_ID: $ios_firebase_app_id_$CI_COMMIT_BRANCH
 
 stages:
-  - Setup
   - Build
   - Distribution
 
@@ -31,7 +30,6 @@ Build APK:
     - curl --silent "https://gitlab.com/gitlab-org/incubation-engineering/mobile-devops/download-secure-files/-/raw/main/installer" | bash
     - mv upload-keystore.jks android/app/upload-keystore.jks
     - mv key.properties android/key.properties
-    - fvm flutter pub get
     - |
       BUILD_COMMAND="fvm flutter build apk -t lib/main_${FLAVOR}.dart --flavor ${FLAVOR}"
       if [ "$CI_COMMIT_BRANCH" = {{prod_branch}} ]; then
@@ -50,17 +48,8 @@ Build IPA:
   stage: Build
   before_script: *setup-flutterfire
   script:
-    - fvm flutter pub get
     - rm ios/Podfile.lock
-    - cd ios && pod install --repo-update
-    - cd ..
-    - |
-      BUILD_COMMAND="fvm flutter build ipa -t lib/main_${FLAVOR}.dart --flavor ${FLAVOR}"
-      if [ "$CI_COMMIT_BRANCH" = {{beta_branch}} ]; then
-        BUILD_COMMAND="$BUILD_COMMAND --export-method ad-hoc"
-      fi
-      echo "Running: $BUILD_COMMAND"
-      eval $BUILD_COMMAND
+    - fvm flutter build ipa -t lib/main_${FLAVOR}.dart --flavor ${FLAVOR} --export-method=ad-hoc
     - mv build/ios/ipa/*.ipa app.ipa
   artifacts:
     paths:
@@ -72,11 +61,12 @@ Firebase Dist.:
   script:
     - OUTPUT=$(git log --grep="^feat:" --pretty=format:"%s")
     - echo $OUTPUT
-    - firebase appdistribution:distribute build/app/outputs/flutter-apk/app-$FLAVOR-release.apk --app $ANDROID_FIREBASE_APP_ID --release-notes "$OUTPUT" --groups {{firebase_group}} --token $FIREBASE_TOKEN
-    - firebase appdistribution:distribute app.ipa --app $IOS_FIREBASE_APP_ID --release-notes "$OUTPUT" --groups {{firebase_group}} --token $FIREBASE_TOKEN
+    - firebase appdistribution:distribute build/app/outputs/flutter-apk/app-$FLAVOR-release.apk --app $ANDROID_FIREBASE_APP_ID --release-notes "$OUTPUT" --groups "{{firebase_group}}" --token $FIREBASE_TOKEN
+    - firebase appdistribution:distribute app.ipa --app $IOS_FIREBASE_APP_ID --release-notes "$OUTPUT" --groups "{{firebase_group}}" --token $FIREBASE_TOKEN
 
 Cleanup:
   stage: .post
   script:
     - fvm flutter clean
-    - cd ios && pod deintegrate
+    - rm -rf ios/Pods
+    - rm -rf android/.gradle

--- a/bricks/gitlab_pipelines/__brick__/.gitlab/deploy.yml
+++ b/bricks/gitlab_pipelines/__brick__/.gitlab/deploy.yml
@@ -30,6 +30,7 @@ Build APK:
     - curl --silent "https://gitlab.com/gitlab-org/incubation-engineering/mobile-devops/download-secure-files/-/raw/main/installer" | bash
     - mv upload-keystore.jks android/app/upload-keystore.jks
     - mv key.properties android/key.properties
+    - fvm dart run build_runner build --delete-conflicting-outputs
     - |
       BUILD_COMMAND="fvm flutter build apk -t lib/main_${FLAVOR}.dart --flavor ${FLAVOR}"
       if [ "$CI_COMMIT_BRANCH" = {{prod_branch}} ]; then
@@ -48,6 +49,7 @@ Build IPA:
   stage: Build
   before_script: *setup-flutterfire
   script:
+    - fvm dart run build_runner build --delete-conflicting-outputs
     - rm ios/Podfile.lock
     - fvm flutter build ipa -t lib/main_${FLAVOR}.dart --flavor ${FLAVOR} --export-method=ad-hoc
     - mv build/ios/ipa/*.ipa app.ipa

--- a/bricks/gitlab_pipelines/__brick__/.gitlab/test.yml
+++ b/bricks/gitlab_pipelines/__brick__/.gitlab/test.yml
@@ -29,6 +29,7 @@ Static Analysis:
   script:
     - fvm list
     - fvm flutter pub get
+    - fvm dart run build_runner build --delete-conflicting-outputs
     - fvm dart format -l 120 lib/l10n
     - fvm dart format -l 120 --set-exit-if-changed .
     - fvm flutter analyze .
@@ -37,6 +38,7 @@ Testing:
   stage: Testing
   script:
     - fvm flutter pub get
+    - fvm dart run build_runner build --delete-conflicting-outputs
     - fvm flutter test --coverage
     - lcov --remove coverage/lcov.info 'lib/l10n/arb/' --output-file coverage/new_lcov.info
     - genhtml coverage/new_lcov.info --output-directory coverage/html

--- a/bricks/gitlab_pipelines/__brick__/.gitlab/test.yml
+++ b/bricks/gitlab_pipelines/__brick__/.gitlab/test.yml
@@ -57,4 +57,3 @@ Cleanup:
   stage: .post
   script:
     - fvm flutter clean
-    - cd ios && pod deintegrate

--- a/bricks/gitlab_pipelines/__brick__/.gitlab/test.yml
+++ b/bricks/gitlab_pipelines/__brick__/.gitlab/test.yml
@@ -27,7 +27,7 @@ Static Analysis:
   stage: Check Format
   before_script: *create_firebase_options
   script:
-    - fvm flutter --version
+    - fvm list
     - fvm flutter pub get
     - fvm dart format -l 120 lib/l10n
     - fvm dart format -l 120 --set-exit-if-changed .
@@ -36,6 +36,7 @@ Static Analysis:
 Testing:
   stage: Testing
   script:
+    - fvm flutter pub get
     - fvm flutter test --coverage
     - lcov --remove coverage/lcov.info 'lib/l10n/arb/' --output-file coverage/new_lcov.info
     - genhtml coverage/new_lcov.info --output-directory coverage/html


### PR DESCRIPTION
- remove unused setup stage
- remove unnecessary setting .pre and .post in stages
- remove unnecessary pod deintegrate in test workflow
- remove redundant flutter pub get when building apk and ipa
- remove checking to include export method flag when building ipa to always using ad hoc
- add missing = in export method flag when building ipa
- wrap groups flag value with quotation marks
- replace pod deintegrate in deploy workflow with deleting pods and .gradle directories instead
- update changelogs