### PR TITLE
fix: load code review files from CI variables

### DIFF
--- a/bricks/gitlab_pipelines/__brick__/.gitlab/code-review.yml
+++ b/bricks/gitlab_pipelines/__brick__/.gitlab/code-review.yml
@@ -10,18 +10,17 @@ Reviewer:
   tags:
     - {{tags}}
   variables:
-    # Secure Files are downloaded to the root directory
-    SECURE_FILES_DOWNLOAD_PATH: "/"
     DANGER_GITLAB_API_TOKEN: $GITLAB_TOKEN
     GEMINI_API_KEY: $GEMINI_API_KEY
   before_script:
     - echo "Verifying Node.js and npm versions..."
     - node -v
     - npm -v
-    - echo "Downloading Secure Files..."
-    # This command downloads the uploaded files (package.json and danger.js)
-    # into the path specified by SECURE_FILES_DOWNLOAD_PATH (which is '/')
-    - curl --silent "https://gitlab.com/gitlab-org/incubation-engineering/mobile-devops/download-secure-files/-/raw/main/installer" | bash
+    # - echo "Downloading Secure Files..."
+    # - curl --silent "https://gitlab.com/gitlab-org/incubation-engineering/mobile-devops/download-secure-files/-/raw/main/installer" | bash
+    - echo "Creating code review files from CI/CD variables..."
+    - printf '%s' "$CODE_REVIEW" > danger.js
+    - printf '%s' "$CODE_REVIEW_DEPS" > package.json
     - echo "Installing project dependencies...."
     - npm install
   script:


### PR DESCRIPTION
## Summary

Updates the `gitlab_pipelines` brick merge request review workflow so generated projects no longer depend on GitLab Secure Files for the Danger JS setup files.

The review job now creates:

- `danger.js` from the `CODE_REVIEW` CI/CD variable
- `package.json` from the `CODE_REVIEW_DEPS` CI/CD variable

The previous Secure Files download step is left commented out in the generated pipeline as a migration reference.

## Why

Projects using this brick can now configure the code review workflow directly through GitLab CI/CD variables instead of uploading and maintaining `danger.js` and `package.json` as Secure Files. This makes the setup easier to copy between projects and keeps the generated pipeline self-contained around CI variable configuration.

## Changes

- Removed the active `SECURE_FILES_DOWNLOAD_PATH` variable from the Reviewer job.
- Commented out the Secure Files installer step.
- Added file creation for `danger.js` from `$CODE_REVIEW`.
- Added file creation for `package.json` from `$CODE_REVIEW_DEPS`.
- Kept the existing `npm install` and `npx danger ci --dangerfile danger.js` execution flow.

## GitLab variable requirements

Generated projects should define these CI/CD variables before enabling the merge request review job:

- `CODE_REVIEW`: full contents of the Danger file to write to `danger.js`
- `CODE_REVIEW_DEPS`: full contents of the npm dependency manifest to write to `package.json`
- `GITLAB_TOKEN`: token used by Danger through `DANGER_GITLAB_API_TOKEN`
- `GEMINI_API_KEY`: key used by the existing code review script

## Verification

- Parsed `bricks/gitlab_pipelines/__brick__/.gitlab/code-review.yml` with Ruby YAML loading and aliases enabled.

## Notes

The `printf` commands redirect output to files, so the variable contents are not printed to normal job logs. If GitLab debug tracing is enabled, shell command tracing may still expose expanded command arguments, so debug tracing should remain disabled for pipelines using sensitive variable values.