### PR TITLE
fix: harden GitLab pipeline templates

### DIFF
--- a/bricks/gitlab_pipelines/README.md
+++ b/bricks/gitlab_pipelines/README.md
@@ -26,7 +26,7 @@ A mason brick to generate the Gitlab Pipelines yml files for CI/CD
 
 1. Setup Gitlab Runner
 2. Add necessary environment variables in **Gitlab CI/CD Settings > Variables**
-3. Upload `key.properties`, `upload-keystore.jks`, `dangerfile.js` files in **Gitlab CI/CD Settings > Secure Files**
+3. Upload `key.properties`, `upload-keystore.jks` files in **Gitlab CI/CD Settings > Secure Files**
 4. Create a group for the Firebase testers
 5. Package name for both iOS and Android should be the same
 
@@ -37,5 +37,27 @@ A mason brick to generate the Gitlab Pipelines yml files for CI/CD
 1. Gitlab Runner Tags to be used
 2. Branch names for the dev, beta, and prod environments
 3. Firebase Testers Group name for Firebase Distribution
+
+## CI/CD Variables Required for Deployments
+
+Set these variables in **Gitlab CI/CD Settings > Variables**:
+
+### Production
+- `PROD_FIREBASE_PROJECT_ID`
+- `PROD_PACKAGE_NAME`
+- `PROD_ANDROID_FIREBASE_APP_ID`
+- `PROD_IOS_FIREBASE_APP_ID`
+
+### Beta
+- `BETA_FIREBASE_PROJECT_ID`
+- `BETA_PACKAGE_NAME`
+- `BETA_ANDROID_FIREBASE_APP_ID`
+- `BETA_IOS_FIREBASE_APP_ID`
+
+### Code Review
+- `CODE_REVIEW`
+- `CODE_REVIEW_DEPS`
+- `GITLAB_TOKEN`
+- `GEMINI_API_KEY`
 
 [1]: https://github.com/felangel/mason

--- a/bricks/gitlab_pipelines/__brick__/.gitlab/deploy.yml
+++ b/bricks/gitlab_pipelines/__brick__/.gitlab/deploy.yml
@@ -8,19 +8,37 @@ default:
 
 variables:
   FLAVOR: $CI_COMMIT_BRANCH
-  FIREBASE_PROJECT_ID: $firebase_project_id_$CI_COMMIT_BRANCH
-  PACKAGE_NAME: $package_name_$CI_COMMIT_BRANCH
-  ANDROID_FIREBASE_APP_ID: $android_firebase_app_id_$CI_COMMIT_BRANCH
-  IOS_FIREBASE_APP_ID: $ios_firebase_app_id_$CI_COMMIT_BRANCH
 
 stages:
   - Build
   - Distribution
 
+.resolve-deploy-vars: &resolve-deploy-vars |
+  if [ "$CI_COMMIT_BRANCH" = "{{prod_branch}}" ]; then
+    export FIREBASE_PROJECT_ID="$PROD_FIREBASE_PROJECT_ID"
+    export PACKAGE_NAME="$PROD_PACKAGE_NAME"
+    export ANDROID_FIREBASE_APP_ID="$PROD_ANDROID_FIREBASE_APP_ID"
+    export IOS_FIREBASE_APP_ID="$PROD_IOS_FIREBASE_APP_ID"
+  elif [ "$CI_COMMIT_BRANCH" = "{{beta_branch}}" ]; then
+    export FIREBASE_PROJECT_ID="$BETA_FIREBASE_PROJECT_ID"
+    export PACKAGE_NAME="$BETA_PACKAGE_NAME"
+    export ANDROID_FIREBASE_APP_ID="$BETA_ANDROID_FIREBASE_APP_ID"
+    export IOS_FIREBASE_APP_ID="$BETA_IOS_FIREBASE_APP_ID"
+  else
+    echo "Unsupported deploy branch: $CI_COMMIT_BRANCH"
+    exit 1
+  fi
+
+  if [ -z "$FIREBASE_PROJECT_ID" ] || [ -z "$PACKAGE_NAME" ] || [ -z "$ANDROID_FIREBASE_APP_ID" ] || [ -z "$IOS_FIREBASE_APP_ID" ]; then
+    echo "Missing deploy CI/CD variables for $CI_COMMIT_BRANCH"
+    exit 1
+  fi
+
 .setup-flutterfire: &setup-flutterfire
+  - *resolve-deploy-vars
   - fvm dart pub global activate flutterfire_cli
   - export PATH="$PATH":"$HOME/.pub-cache/bin"
-  - rm ios/Runner/GoogleService-Info.plist
+  - rm -f ios/Runner/GoogleService-Info.plist
   - fvm exec flutterfire configure --project=$FIREBASE_PROJECT_ID --platforms android,ios -a $PACKAGE_NAME -i $PACKAGE_NAME -y --token $FIREBASE_TOKEN
 
 Build APK:
@@ -61,6 +79,7 @@ Build IPA:
 Firebase Dist.:
   stage: Distribution
   script:
+    - *resolve-deploy-vars
     - OUTPUT=$(git log --grep="^feat:" --pretty=format:"%s")
     - echo $OUTPUT
     - firebase appdistribution:distribute build/app/outputs/flutter-apk/app-$FLAVOR-release.apk --app $ANDROID_FIREBASE_APP_ID --release-notes "$OUTPUT" --groups "{{firebase_group}}" --token $FIREBASE_TOKEN

--- a/bricks/gitlab_pipelines/__brick__/.gitlab/test.yml
+++ b/bricks/gitlab_pipelines/__brick__/.gitlab/test.yml
@@ -30,7 +30,7 @@ Static Analysis:
     - fvm list
     - fvm flutter pub get
     - fvm dart run build_runner build --delete-conflicting-outputs
-    - fvm dart format -l 120 lib/l10n
+    - if [ -d lib/l10n ]; then fvm dart format -l 120 lib/l10n; fi
     - fvm dart format -l 120 --set-exit-if-changed .
     - fvm flutter analyze .
 


### PR DESCRIPTION
## Summary

Hardens the generated GitLab CI templates for push testing and beta/production deployment.

## Changes

- Replaces broken dynamic variable names like `$firebase_project_id_$CI_COMMIT_BRANCH` with explicit branch-based deploy variable resolution.
- Adds clear failure output when required deploy variables are missing.
- Uses `rm -f` for `GoogleService-Info.plist` so first-time or clean checkouts do not fail unnecessarily.
- Guards `lib/l10n` formatting so projects without localization files can still run static analysis.
- Updates the GitLab pipeline README with the required beta, production, and code review variables.

## Required deploy variables

Production:

- `PROD_FIREBASE_PROJECT_ID`
- `PROD_PACKAGE_NAME`
- `PROD_ANDROID_FIREBASE_APP_ID`
- `PROD_IOS_FIREBASE_APP_ID`

Beta:

- `BETA_FIREBASE_PROJECT_ID`
- `BETA_PACKAGE_NAME`
- `BETA_ANDROID_FIREBASE_APP_ID`
- `BETA_IOS_FIREBASE_APP_ID`

## Verification

- Parsed `bricks/gitlab_pipelines/__brick__/.gitlab/deploy.yml` with Ruby YAML loading and aliases enabled.
- Parsed `bricks/gitlab_pipelines/__brick__/.gitlab/test.yml` with Ruby YAML loading and aliases enabled.