### PR TITLE
fix: stabilize auto_route brick output

### DIFF
--- a/bricks/auto_route/__brick__/lib/app/app_route_observer.dart
+++ b/bricks/auto_route/__brick__/lib/app/app_route_observer.dart
@@ -2,8 +2,6 @@ import 'package:auto_route/auto_route.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'router/app_router.gr.dart';
 
 class AppRouteObserver extends AutoRouterObserver {
   @override
@@ -18,7 +16,7 @@ class AppRouteObserver extends AutoRouterObserver {
 
   @override
   void didReplace({Route? newRoute, Route? oldRoute}) {
-    if (newRoute == null) return;
+    if (newRoute == null || newRoute.data == null) return;
 
     debugPrint('AppRouteObserver didReplace: ${newRoute.data!.name}');
 
@@ -28,13 +26,15 @@ class AppRouteObserver extends AutoRouterObserver {
 
   @override
   void didRemove(Route route, Route? previousRoute) {
-    if (previousRoute == null) return;
+    if (previousRoute == null || previousRoute.data == null) return;
 
     debugPrint('AppRouteObserver didRemove: ${previousRoute.data!.name}');
 
     if (!kIsWeb)
-      FirebaseCrashlytics.instance
-          .setCustomKey('route', previousRoute.data!.name);
+      FirebaseCrashlytics.instance.setCustomKey(
+        'route',
+        previousRoute.data!.name,
+      );
   }
 
   @override
@@ -44,7 +44,9 @@ class AppRouteObserver extends AutoRouterObserver {
     debugPrint('AppRouteObserver didPop: ${previousRoute.data!.name}');
 
     if (!kIsWeb)
-      FirebaseCrashlytics.instance
-          .setCustomKey('route', previousRoute.data!.name);
+      FirebaseCrashlytics.instance.setCustomKey(
+        'route',
+        previousRoute.data!.name,
+      );
   }
 }

--- a/bricks/auto_route/__brick__/lib/app/router/nested_route_containers.dart
+++ b/bricks/auto_route/__brick__/lib/app/router/nested_route_containers.dart
@@ -2,7 +2,6 @@ import 'package:auto_route/auto_route.dart';
 // import 'package:firebase_analytics/firebase_analytics.dart';
 // import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../app_route_observer.dart';
 

--- a/bricks/auto_route/hooks/pre_gen.dart
+++ b/bricks/auto_route/hooks/pre_gen.dart
@@ -2,20 +2,26 @@ import 'dart:io';
 
 import 'package:mason/mason.dart';
 
-void run(HookContext context) async {
+Future<void> run(HookContext context) async {
   final progress = context.logger.progress('Installing Packages');
 
-  await Process.run(
-    'flutter',
-    ['pub', 'add', 'auto_route', 'flutter_secure_storage'],
-    runInShell: true,
-  );
+  await Process.run('flutter', [
+    'pub',
+    'add',
+    'auto_route',
+    'firebase_crashlytics',
+    'flutter_secure_storage',
+  ], runInShell: true);
 
-  await Process.run(
-    'flutter',
-    ['pub', 'get'],
-    runInShell: true,
-  );
+  await Process.run('flutter', [
+    'pub',
+    'add',
+    '--dev',
+    'build_runner',
+    'auto_route_generator',
+  ], runInShell: true);
+
+  await Process.run('flutter', ['pub', 'get'], runInShell: true);
 
   progress.complete();
   context.logger.success('Done instaling packages!');


### PR DESCRIPTION
## Summary

Fixes generated `auto_route` output so the brick installs the dependencies it needs and avoids nullable route-data crashes.

## Changes

- Converts the pre-gen hook to `Future<void>` so Mason can await package installation.
- Adds `firebase_crashlytics`, which is imported by the generated route observer.
- Adds `build_runner` and `auto_route_generator` as dev dependencies before running post-generation codegen.
- Removes unused `flutter_bloc` and generated router imports from generated templates.
- Guards nullable route data in `didReplace` and `didRemove`.

## Verification

- Ran `dart format` on the changed hook and generated Dart templates.
- Ran `git diff --check` for the `auto_route` brick.