### PR TITLE
fix: bootstrap remote_config output

### DIFF
--- a/bricks/remote_config/__brick__/lib/main.dart
+++ b/bricks/remote_config/__brick__/lib/main.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 
-import 'package:consumer/app/services/remote_config_service.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+
+import 'app/services/remote_config_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  // Initialize the Remote Config service (call this after Firebase.initializeApp())
+  await Firebase.initializeApp();
   await RemoteConfigService.instance.initialize();
 
   runApp(const MyApp());
@@ -51,26 +53,23 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    final isFeatureEnabled = _remoteConfigService.getBool(
-      rcIsFeatureEnabled,
-    );
-    return Scaffold(
-      body: Container(
-        alignment: Alignment.center,
-        padding: const EdgeInsets.all(32),
-        child: _isAppMaintenance
-            ? const MaintenancePage()
-            : HomePage(isNewFeatureEnabled: isFeatureEnabled),
+    final isFeatureEnabled = _remoteConfigService.getBool(rcIsFeatureEnabled);
+    return MaterialApp(
+      home: Scaffold(
+        body: Container(
+          alignment: Alignment.center,
+          padding: const EdgeInsets.all(32),
+          child: _isAppMaintenance
+              ? const MaintenancePage()
+              : HomePage(isNewFeatureEnabled: isFeatureEnabled),
+        ),
       ),
     );
   }
 }
 
 class HomePage extends StatelessWidget {
-  const HomePage({
-    required this.isNewFeatureEnabled,
-    super.key,
-  });
+  const HomePage({required this.isNewFeatureEnabled, super.key});
 
   final bool isNewFeatureEnabled;
 
@@ -81,10 +80,7 @@ class HomePage extends StatelessWidget {
       children: [
         const Text(
           'Home Page',
-          style: TextStyle(
-            fontSize: 24,
-            fontWeight: FontWeight.bold,
-          ),
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
         ),
         const SizedBox(height: 32),
         ElevatedButton(
@@ -109,16 +105,10 @@ class MaintenancePage extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       spacing: 32,
       children: [
-        Icon(
-          Icons.construction,
-          size: 48,
-        ),
+        Icon(Icons.construction, size: 48),
         Text(
           'Under Maintenance',
-          style: TextStyle(
-            fontSize: 24,
-            fontWeight: FontWeight.bold,
-          ),
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
         ),
       ],
     );

--- a/bricks/remote_config/hooks/pre_gen.dart
+++ b/bricks/remote_config/hooks/pre_gen.dart
@@ -2,12 +2,12 @@ import 'dart:io';
 
 import 'package:mason/mason.dart';
 
-void run(HookContext context) async {
+Future<void> run(HookContext context) async {
   final progress = context.logger.progress('Installing Packages');
 
   await Process.run(
     'flutter',
-    ['pub', 'add', 'auto_route', 'firebase_remote_config'],
+    ['pub', 'add', 'firebase_core', 'firebase_remote_config'],
     runInShell: true,
   );
 


### PR DESCRIPTION
## Summary

Fixes generated `remote_config` bootstrap code so it works outside the original package name and initializes Firebase before Remote Config.

## Changes

- Replaces the hardcoded `package:consumer/...` import with a relative import.
- Adds `firebase_core` to the generated app bootstrap.
- Calls `Firebase.initializeApp()` before initializing `RemoteConfigService`.
- Wraps the generated root UI in `MaterialApp` so `Scaffold` has the expected app context.
- Updates the hook to install `firebase_core` and removes the unrelated `auto_route` dependency.
- Converts the hook to `Future<void>` so Mason can await package installation.

## Verification

- Ran `dart format` on the changed hook and generated Dart file.
- Ran `git diff --check` for the `remote_config` brick.