### PR TITLE
fix: harden API and validator bricks

### DIFF
--- a/bricks/api_service/README.md
+++ b/bricks/api_service/README.md
@@ -35,6 +35,14 @@ if (response.isSuccess()) {
 
 For larger apps, it's best to wrap the API calls in a repository:
 
+Before making authorized requests, configure how the API service should read the current token:
+
+```dart
+Api.tokenProvider = () async {
+  return secureStorage.read(key: 'auth_token');
+};
+```
+
 **Repository Implementation:**
 ```dart
 class AuthRepository {

--- a/bricks/api_service/__brick__/lib/services/api.dart
+++ b/bricks/api_service/__brick__/lib/services/api.dart
@@ -18,6 +18,7 @@ class Api {
   static Duration timeoutDuration = const Duration(minutes: 1);
 
   static final dioRetry = RetryOptions(maxAttempts: 3);
+  static FutureOr<String?> Function()? tokenProvider;
 
   static Dio dio = Dio(
     BaseOptions(
@@ -26,12 +27,15 @@ class Api {
       receiveTimeout: timeoutDuration,
       validateStatus: (statusCode) {
         if (statusCode == null) return false;
-        
+
         // Return true for common error codes so we can parse the response body
-        if (statusCode == 422 || statusCode == 401 || statusCode == 400 || statusCode == 404) {
+        if (statusCode == 422 ||
+            statusCode == 401 ||
+            statusCode == 400 ||
+            statusCode == 404) {
           return true;
         }
-        
+
         return statusCode >= 200 && statusCode < 300;
       },
     ),
@@ -44,11 +48,9 @@ class Api {
     };
 
     if (authorized) {
-      // TODO: Replace with your actual token retrieval logic
-      String? token = 'auth token here';
-      debugPrint('authToken: $token');
+      final token = await tokenProvider?.call();
 
-      if (token != null) {
+      if (token != null && token.isNotEmpty) {
         headers['Authorization'] = 'Bearer $token';
       }
     }
@@ -81,10 +83,7 @@ class Api {
         () => dio.get(
           '$apiUrl/$path',
           queryParameters: params,
-          options: Options(
-            headers: headers,
-            responseType: responseType,
-          ),
+          options: Options(headers: headers, responseType: responseType),
         ),
         retryIf: _shouldRetry,
       );

--- a/bricks/api_service/__brick__/lib/services/api_response.dart
+++ b/bricks/api_service/__brick__/lib/services/api_response.dart
@@ -14,19 +14,19 @@ class APIResponse {
 
   /// Factory constructor to create an [APIResponse] from a Dio [Response].
   factory APIResponse.fromResponse(Response<dynamic> response) {
-    final status = APIStatusHandler.parseStatusCode(statusCode: response.statusCode);
+    final status = APIStatusHandler.parseStatusCode(
+      statusCode: response.statusCode,
+    );
     String? error;
-    
-    if (status != ResponseStatus.success && response.data is Map<String, dynamic>) {
-       error = APIExceptionMessageHandler.parseResponseBody(
-        result: response.data as Map<String, dynamic>);
+
+    if (status != ResponseStatus.success &&
+        response.data is Map<String, dynamic>) {
+      error = APIExceptionMessageHandler.parseResponseBody(
+        result: response.data as Map<String, dynamic>,
+      );
     }
 
-    return APIResponse(
-      response: response,
-      errorMessage: error,
-      status: status,
-    );
+    return APIResponse(response: response, errorMessage: error, status: status);
   }
 
   /// Helper to get the response data.
@@ -58,8 +58,10 @@ class APIStatusHandler {
       return ResponseStatus.unauthorized;
     } else if (statusCode == 404) {
       return ResponseStatus.notFound;
-    } else if (statusCode < 200 || statusCode >= 400) {
+    } else if (statusCode == 403) {
       return ResponseStatus.forbidden;
+    } else if (statusCode < 200 || statusCode >= 400) {
+      return ResponseStatus.error;
     } else {
       return ResponseStatus.error;
     }

--- a/bricks/validator/__brick__/lib/utils/validator/validator.dart
+++ b/bricks/validator/__brick__/lib/utils/validator/validator.dart
@@ -15,7 +15,8 @@ class Validator {
       final min = double.parse(minMax[0]);
       final max = double.parse(minMax[1]);
 
-      if (_rules['min']!(text, min.toString()) is String || _rules['max']!(text, max.toString()) is String) {
+      if (_rules['min']!(text, min.toString()) is String ||
+          _rules['max']!(text, max.toString()) is String) {
         return 'This must be between $min and $max.';
       }
 
@@ -50,7 +51,8 @@ class Validator {
     'min': (String text, String value) {
       if (text.isEmpty) return null;
 
-      if (text.length < double.parse(value)) return 'This must be at least $value characters.';
+      if (text.length < double.parse(value))
+        return 'This must be at least $value characters.';
 
       return true;
     },
@@ -60,7 +62,8 @@ class Validator {
     'max': (String text, String value) {
       if (text.isEmpty) return null;
 
-      if (double.parse(value) < text.length) return 'Max of $value characters only';
+      if (double.parse(value) < text.length)
+        return 'Max of $value characters only';
 
       return true;
     },
@@ -116,16 +119,25 @@ class Validator {
   /// Validates a [text] input based on a list of [rules]
   ///
   static String? validate({String? text, List<String>? rules}) {
-    for (final rule in rules!) {
+    final value = text ?? '';
+    final activeRules = rules ?? const <String>[];
+
+    for (final rule in activeRules) {
       dynamic error;
       final ruleComponents = rule.split(':');
+      final ruleName = ruleComponents[0];
+      final validator = Validator._rules[ruleName];
+
+      if (validator == null) {
+        return 'Invalid validation rule: $ruleName.';
+      }
 
       if (ruleComponents.length == 1) {
-        error = Validator._rules[ruleComponents[0]]!(text);
+        error = validator(value);
       } else if (ruleComponents.length == 2) {
-        error = Validator._rules[ruleComponents[0]]!(text, ruleComponents[1]);
+        error = validator(value, ruleComponents[1]);
       } else {
-        assert(false, 'Invalid rule.');
+        return 'Invalid validation rule: $rule.';
       }
 
       if (error is String) return error;


### PR DESCRIPTION
## Summary

Fixes generated API and validator code so templates do not ship placeholder auth behavior, misclassify common HTTP errors, or crash on nullable form validator inputs.

## Changes

- Adds `Api.tokenProvider` so apps can provide the current auth token.
- Removes the placeholder `auth token here` value.
- Stops logging auth tokens in generated API code.
- Maps only HTTP 403 to `ResponseStatus.forbidden`; other 4xx/5xx responses now map to `ResponseStatus.error`.
- Makes `Validator.validate` tolerate nullable `text` and nullable `rules`.
- Returns validation errors for unknown or malformed rules instead of throwing.
- Adds README guidance for configuring `Api.tokenProvider`.

## Verification

- Ran `dart format` on the changed generated Dart files.
- Ran `git diff --check` for the `api_service` and `validator` bricks.