### PR TITLE
chore: align brick metadata

### DIFF
--- a/bricks/deploy/brick.yaml
+++ b/bricks/deploy/brick.yaml
@@ -67,4 +67,4 @@ vars:
   production_ios_app_id: 
     type: string
     description: Production iOS App Id
-    default: 1:1234567890:android:abcdef123456
+    default: 1:1234567890:ios:abcdef123456

--- a/bricks/gitlab_pipelines/brick.yaml
+++ b/bricks/gitlab_pipelines/brick.yaml
@@ -1,7 +1,7 @@
 name: gitlab_pipelines
 description: A mason brick to generate the Gitlab Pipelines yml files for CI/CD
 
-version: 0.2.0
+version: 0.3.0
 
 environment:
   mason: ^0.1.1


### PR DESCRIPTION
## Summary

Cleans up small brick metadata drift found during review.

## Changes

- Updates `gitlab_pipelines` brick metadata version from `0.2.0` to `0.3.0` to match the changelog.
- Fixes the `deploy_config` production iOS Firebase app id default so it uses an iOS-shaped app id instead of an Android-shaped one.

## Verification

- Parsed `bricks/gitlab_pipelines/brick.yaml` with Ruby YAML loading and aliases enabled.
- Parsed `bricks/deploy/brick.yaml` with Ruby YAML loading and aliases enabled.
- Ran `git diff --check` for the changed metadata files.