### PR TITLE
fix: read code review config from file variables

### DIFF
--- a/bricks/gitlab_pipelines/__brick__/.gitlab/code-review.yml
+++ b/bricks/gitlab_pipelines/__brick__/.gitlab/code-review.yml
@@ -18,9 +18,9 @@ Reviewer:
     - npm -v
     # - echo "Downloading Secure Files..."
     # - curl --silent "https://gitlab.com/gitlab-org/incubation-engineering/mobile-devops/download-secure-files/-/raw/main/installer" | bash
-    - echo "Creating code review files from CI/CD variables..."
-    - printf '%s' "$CODE_REVIEW" > danger.js
-    - printf '%s' "$CODE_REVIEW_DEPS" > package.json
+    - echo "Copying code review files from CI/CD file variables..."
+    - cp "$CODE_REVIEW" danger.js
+    - cp "$CODE_REVIEW_DEPS" package.json
     - echo "Installing project dependencies...."
     - npm install
   script:


### PR DESCRIPTION
## Summary

Updates the generated merge request review pipeline to treat `CODE_REVIEW` and `CODE_REVIEW_DEPS` as GitLab file-type CI/CD variables.

## Why

GitLab file variables expose the environment variable value as the path to a temporary file. The previous `printf` commands worked for normal text variables, but would write the temp file path into `danger.js` and `package.json` when the variables are configured as File variables.

## Changes

- Replaces `printf` with `cp` for `CODE_REVIEW` -> `danger.js`.
- Replaces `printf` with `cp` for `CODE_REVIEW_DEPS` -> `package.json`.
- Updates the job log message to clarify that file variables are expected.

## Verification

- Parsed `bricks/gitlab_pipelines/__brick__/.gitlab/code-review.yml` with Ruby YAML loading and aliases enabled.